### PR TITLE
Removed resque version dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+.idea

--- a/lib/resque/lifecycle.rb
+++ b/lib/resque/lifecycle.rb
@@ -17,7 +17,8 @@ module Resque
       #
       def push(queue, item)
         if item.respond_to?(:[]=)
-          item[:created_at] = Time.now.to_i
+          exists = item.respond_to?(:[]) && item[:created_at]
+          item[:created_at] = Time.now.to_i unless exists
         end
         push_without_lifecycle queue, item
       end

--- a/lib/resque/lifecycle.rb
+++ b/lib/resque/lifecycle.rb
@@ -17,8 +17,8 @@ module Resque
       #
       def push(queue, item)
         if item.respond_to?(:[]=)
-          exists = item.respond_to?(:[]) && item[:created_at]
-          item[:created_at] = Time.now.to_i unless exists
+          exists = item.respond_to?(:[]) && item['created_at']
+          item['created_at'] = Time.now.to_i unless exists
         end
         push_without_lifecycle queue, item
       end

--- a/resque-lifecycle.gemspec
+++ b/resque-lifecycle.gemspec
@@ -44,14 +44,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<shoulda>, [">= 2.10"])
-      s.add_runtime_dependency(%q<resque>, ["= 1.5.2"])
+      s.add_runtime_dependency(%q<resque>)
     else
       s.add_dependency(%q<shoulda>, [">= 2.10"])
-      s.add_dependency(%q<resque>, ["= 1.5.2"])
+      s.add_dependency(%q<resque>)
     end
   else
     s.add_dependency(%q<shoulda>, [">= 2.10"])
-    s.add_dependency(%q<resque>, ["= 1.5.2"])
+    s.add_dependency(%q<resque>)
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,9 +8,21 @@ require 'resque-lifecycle'
 
 module ResqueMock
   extend self
+  @items = {}
+
+  def clear
+    @items = {}
+  end
 
   def push(queue, item)
+    @items[queue] ||= []
+    @items[queue].push(item)
     item
+  end
+
+  def pop(queue)
+    @items[queue] ||= []
+    @items[queue].pop
   end
 
 end

--- a/test/test_lifecycle.rb
+++ b/test/test_lifecycle.rb
@@ -6,8 +6,19 @@ end
 
 class LifecycleTest < Test::Unit::TestCase
 
+  def setup
+    ResqueMock.clear
+  end
+
   should 'add created_at to items with #[]=' do
     assert_not_nil ResqueMock.push('queue', { })[:created_at]
+  end
+
+  should 'not add created_at to items with #[]= if already there' do
+    yesterday = Time.now.to_i - 86400
+    ResqueMock.push('queue', {:created_at => yesterday})
+    existing = ResqueMock.pop('queue')
+    assert_equal yesterday, existing[:created_at]
   end
 
   should 'not modify items missing #[]=' do

--- a/test/test_lifecycle.rb
+++ b/test/test_lifecycle.rb
@@ -11,14 +11,14 @@ class LifecycleTest < Test::Unit::TestCase
   end
 
   should 'add created_at to items with #[]=' do
-    assert_not_nil ResqueMock.push('queue', { })[:created_at]
+    assert_not_nil ResqueMock.push('queue', { })['created_at']
   end
 
   should 'not add created_at to items with #[]= if already there' do
     yesterday = Time.now.to_i - 86400
-    ResqueMock.push('queue', {:created_at => yesterday})
+    ResqueMock.push('queue', {'created_at' => yesterday})
     existing = ResqueMock.pop('queue')
-    assert_equal yesterday, existing[:created_at]
+    assert_equal yesterday, existing['created_at']
   end
 
   should 'not modify items missing #[]=' do


### PR DESCRIPTION
The lib hard-coded to one very specific version of resque that's really old.  I just removed that.  I guess we could make it a minimum version, but I'd be surprised if anyone was running that old a version of resque any more.
